### PR TITLE
Fix rule object syntax

### DIFF
--- a/src/rules/audit/logging-requirements.ts
+++ b/src/rules/audit/logging-requirements.ts
@@ -1,7 +1,7 @@
 import { MCPSecurityRule, AnalysisContext, RuleViolation } from '../../core/types';
 import * as ts from 'typescript';
 
-export const auditLoggingRequirements: MCPSecurityRule = {
+export const auditLoggingRequirements = {
 	id: 'audit-logging',
 	name: 'Audit Logging Requirements',
 	description: 'Ensures comprehensive audit logging for Fox Corp compliance',
@@ -23,9 +23,8 @@ export const auditLoggingRequirements: MCPSecurityRule = {
 		violations.push(...globalViolations);
 
 		return violations;
-	}
-
-  private async checkToolLogging(tool: any, context: AnalysisContext): Promise<RuleViolation[]> {
+	},
+  async checkToolLogging(tool: any, context: AnalysisContext): Promise<RuleViolation[]> {
 		const violations: RuleViolation[] = [];
 
 		// Find tool implementation
@@ -88,9 +87,8 @@ export const auditLoggingRequirements: MCPSecurityRule = {
 		}
 
 		return violations;
-	}
-
-  private checkForLoggingStatements(file: any): { found: boolean; locations: number[] } {
+	},
+  checkForLoggingStatements(file: any): { found: boolean; locations: number[] } {
 		const locations: number[] = [];
 		let found = false;
 
@@ -111,9 +109,8 @@ export const auditLoggingRequirements: MCPSecurityRule = {
 
 		visitor(file.ast);
 		return { found, locations };
-	}
-
-  private checkForErrorLogging(file: any): { found: boolean; locations: number[] } {
+	},
+  checkForErrorLogging(file: any): { found: boolean; locations: number[] } {
 		const locations: number[] = [];
 		let found = false;
 
@@ -133,9 +130,8 @@ export const auditLoggingRequirements: MCPSecurityRule = {
 
 		visitor(file.ast);
 		return { found, locations };
-	}
-
-  private checkForSecurityEventLogging(file: any): { found: boolean; locations: number[] } {
+	},
+  checkForSecurityEventLogging(file: any): { found: boolean; locations: number[] } {
 		const locations: number[] = [];
 		let found = false;
 
@@ -165,9 +161,8 @@ export const auditLoggingRequirements: MCPSecurityRule = {
 
 		visitor(file.ast);
 		return { found, locations };
-	}
-
-private checkFoxCorpLoggingRequirements(tool: any, file: any, context: AnalysisContext): RuleViolation[] {
+	},
+  checkFoxCorpLoggingRequirements(tool: any, file: any, context: AnalysisContext): RuleViolation[] {
 		const violations: RuleViolation[] = [];
 
 		// Fox Corp requires specific fields in audit logs
@@ -212,9 +207,8 @@ private checkFoxCorpLoggingRequirements(tool: any, file: any, context: AnalysisC
 		}
 
 		return violations;
-	}
-
- private findLoggingCalls(file: any): Array<{ line: number; args: ts.Node[] }> {
+	},
+  findLoggingCalls(file: any): Array<{ line: number; args: ts.Node[] }> {
 		const calls: Array<{ line: number; args: ts.Node[] }> = [];
 
 		const visitor = (node: ts.Node) => {
@@ -235,9 +229,8 @@ private checkFoxCorpLoggingRequirements(tool: any, file: any, context: AnalysisC
 
 		visitor(file.ast);
 		return calls;
-	}
-
- private checkRequiredFields(call: any, requiredFields: string[], file: any): string[] {
+	},
+  checkRequiredFields(call: any, requiredFields: string[], file: any): string[] {
 		const missingFields: string[] = [];
 
 		// Simple heuristic: check if the logging call includes the required fields
@@ -250,9 +243,8 @@ private checkFoxCorpLoggingRequirements(tool: any, file: any, context: AnalysisC
 		}
 
 		return missingFields;
-	}
-
- private checkPIIInLogs(file: any, context: AnalysisContext): RuleViolation[] {
+	},
+  checkPIIInLogs(file: any, context: AnalysisContext): RuleViolation[] {
 		const violations: RuleViolation[] = [];
 		const piiPatterns = [
 			/email/i,
@@ -286,9 +278,8 @@ private checkFoxCorpLoggingRequirements(tool: any, file: any, context: AnalysisC
 
 		visitor(file.ast);
 		return violations;
-	}
-
- private checkStreamingContentLogging(file: any, context: AnalysisContext): RuleViolation[] {
+	},
+  checkStreamingContentLogging(file: any, context: AnalysisContext): RuleViolation[] {
 		const violations: RuleViolation[] = [];
 
 		// Streaming content access should be logged with specific details
@@ -322,9 +313,8 @@ private checkFoxCorpLoggingRequirements(tool: any, file: any, context: AnalysisC
 
 		visitor(file.ast);
 		return violations;
-	}
-
- private isHighRiskTool(tool: any): boolean {
+	},
+  isHighRiskTool(tool: any): boolean {
 		const highRiskPatterns = [
 			/admin/i,
 			/system/i,
@@ -339,9 +329,8 @@ private checkFoxCorpLoggingRequirements(tool: any, file: any, context: AnalysisC
 		return highRiskPatterns.some(pattern =>
 			pattern.test(tool.name) || pattern.test(tool.description)
 		);
-	}
-
- private isStreamingRelatedTool(tool: any): boolean {
+	},
+  isStreamingRelatedTool(tool: any): boolean {
 		const streamingPatterns = [
 			/stream/i,
 			/video/i,
@@ -353,9 +342,8 @@ private checkFoxCorpLoggingRequirements(tool: any, file: any, context: AnalysisC
 		return streamingPatterns.some(pattern =>
 			pattern.test(tool.name) || pattern.test(tool.description)
 		);
-	}
-
- private containsLoggingInBlock(block: ts.Block): boolean {
+	},
+  containsLoggingInBlock(block: ts.Block): boolean {
 		let hasLogging = false;
 
 		const visitor = (node: ts.Node) => {
@@ -369,9 +357,8 @@ private checkFoxCorpLoggingRequirements(tool: any, file: any, context: AnalysisC
 
 		visitor(block);
 		return hasLogging;
-	}
-
- private isLoggingCall(node: ts.CallExpression): boolean {
+	},
+  isLoggingCall(node: ts.CallExpression): boolean {
 		if (ts.isPropertyAccessExpression(node.expression)) {
 			const obj = node.expression.expression;
 			const method = node.expression.name.text;
@@ -381,9 +368,8 @@ private checkFoxCorpLoggingRequirements(tool: any, file: any, context: AnalysisC
 					['log', 'info', 'warn', 'error'].includes(method));
 		}
 		return false;
-	}
-
- private hasNearbyLogging(node: ts.Node, file: any): boolean {
+	},
+  hasNearbyLogging(node: ts.Node, file: any): boolean {
 		// Simple heuristic: check if there's a logging call within 5 lines
 		const nodeLineNumber = this.getLineNumber(file.ast, node);
 		const loggingCalls = this.findLoggingCalls(file);
@@ -391,9 +377,8 @@ private checkFoxCorpLoggingRequirements(tool: any, file: any, context: AnalysisC
 		return loggingCalls.some(call =>
 			Math.abs(call.line - nodeLineNumber) <= 5
 		);
-	}
-
- private checkGlobalAuditConfig(context: AnalysisContext): RuleViolation[] {
+	},
+  checkGlobalAuditConfig(context: AnalysisContext): RuleViolation[] {
 		const violations: RuleViolation[] = [];
 
 		// Check for audit configuration file
@@ -429,9 +414,9 @@ private checkFoxCorpLoggingRequirements(tool: any, file: any, context: AnalysisC
 		}
 
 		return violations;
-	}
-
- private getLineNumber(sourceFile: ts.SourceFile, node: ts.Node): number {
+	},
+  getLineNumber(sourceFile: ts.SourceFile, node: ts.Node): number {
 		return sourceFile.getLineAndCharacterOfPosition(node.getStart()).line + 1;
 	}
-};
+} as MCPSecurityRule;
+

--- a/src/rules/authentication/auth-required.ts
+++ b/src/rules/authentication/auth-required.ts
@@ -1,7 +1,7 @@
 import { MCPSecurityRule, AnalysisContext, RuleViolation } from '../../core/types';
 import * as ts from 'typescript';
 
-export const authRequired: MCPSecurityRule = {
+export const authRequired = {
     id: 'auth-required',
     name: 'Authentication Required',
     description: 'Ensures all MCP tools require proper authentication before execution',
@@ -27,9 +27,8 @@ export const authRequired: MCPSecurityRule = {
         violations.push(...implViolations);
 
         return violations;
-    }
-
-  private async checkToolAuthentication(tool: any, context: AnalysisContext): Promise<RuleViolation[]> {
+    },
+  async checkToolAuthentication(tool: any, context: AnalysisContext): Promise<RuleViolation[]> {
         const violations: RuleViolation[] = [];
 
         // Check if tool explicitly requires authentication
@@ -54,15 +53,13 @@ export const authRequired: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
-  private hasAuthenticationRequirement(tool: any): boolean {
+    },
+  hasAuthenticationRequirement(tool: any): boolean {
         return tool.authRequired === true ||
             tool.authentication === 'required' ||
             (tool.permissions && tool.permissions.length > 0);
-    }
-
-  private async checkToolAuthImplementation(tool: any, context: AnalysisContext): Promise<RuleViolation[]> {
+    },
+  async checkToolAuthImplementation(tool: any, context: AnalysisContext): Promise<RuleViolation[]> {
         const violations: RuleViolation[] = [];
 
         // Find tool implementation file
@@ -118,9 +115,8 @@ export const authRequired: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
-  private hasAuthenticationCheck(file: any): boolean {
+    },
+  hasAuthenticationCheck(file: any): boolean {
         const content = file.content.toLowerCase();
         const authPatterns = [
             /authenticate/,
@@ -135,9 +131,8 @@ export const authRequired: MCPSecurityRule = {
         ];
 
         return authPatterns.some(pattern => pattern.test(content));
-    }
-
-  private hasTokenValidation(file: any): boolean {
+    },
+  hasTokenValidation(file: any): boolean {
         const content = file.content.toLowerCase();
         const tokenPatterns = [
             /jwt\.verify/,
@@ -150,9 +145,8 @@ export const authRequired: MCPSecurityRule = {
         ];
 
         return tokenPatterns.some(pattern => pattern.test(content));
-    }
-
-  private usesTokenAuth(file: any): boolean {
+    },
+  usesTokenAuth(file: any): boolean {
         const content = file.content.toLowerCase();
         const tokenUsagePatterns = [
             /bearer.*token/,
@@ -163,9 +157,8 @@ export const authRequired: MCPSecurityRule = {
         ];
 
         return tokenUsagePatterns.some(pattern => pattern.test(content));
-    }
-
-  private hasSessionValidation(file: any): boolean {
+    },
+  hasSessionValidation(file: any): boolean {
         const content = file.content.toLowerCase();
         const sessionPatterns = [
             /session\.check/,
@@ -176,9 +169,8 @@ export const authRequired: MCPSecurityRule = {
         ];
 
         return sessionPatterns.some(pattern => pattern.test(content));
-    }
-
-  private usesSessionAuth(file: any): boolean {
+    },
+  usesSessionAuth(file: any): boolean {
         const content = file.content.toLowerCase();
         const sessionUsagePatterns = [
             /req\.session/,
@@ -188,9 +180,8 @@ export const authRequired: MCPSecurityRule = {
         ];
 
         return sessionUsagePatterns.some(pattern => pattern.test(content));
-    }
-
-  private isHighRiskTool(tool: any): boolean {
+    },
+  isHighRiskTool(tool: any): boolean {
         const highRiskPatterns = [
             /admin/i,
             /system/i,
@@ -209,9 +200,8 @@ export const authRequired: MCPSecurityRule = {
         return highRiskPatterns.some(pattern =>
             pattern.test(tool.name) || pattern.test(tool.description || '')
         );
-    }
-
-  private checkHighRiskToolAuth(tool: any, context: AnalysisContext): RuleViolation[] {
+    },
+  checkHighRiskToolAuth(tool: any, context: AnalysisContext): RuleViolation[] {
         const violations: RuleViolation[] = [];
 
         // High-risk tools should require strong authentication
@@ -237,30 +227,26 @@ export const authRequired: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
-  private hasStrongAuthentication(tool: any): boolean {
+    },
+  hasStrongAuthentication(tool: any): boolean {
         return tool.authentication === 'mfa' ||
             tool.authentication === 'certificate' ||
             tool.strongAuth === true;
-    }
-
-  private hasAdditionalAuthorization(tool: any): boolean {
+    },
+  hasAdditionalAuthorization(tool: any): boolean {
         return (tool.permissions && tool.permissions.length > 0) ||
             tool.roles ||
             tool.authorization;
-    }
-
-  private getToolCategory(tool: any): string {
+    },
+  getToolCategory(tool: any): string {
         if (tool.name.toLowerCase().includes('admin')) return 'Administrative';
         if (tool.name.toLowerCase().includes('system')) return 'System';
         if (tool.name.toLowerCase().includes('stream')) return 'Streaming';
         if (tool.name.toLowerCase().includes('file')) return 'File System';
         if (tool.name.toLowerCase().includes('database')) return 'Database';
         return 'General';
-    }
-
-  private checkGlobalAuthentication(context: AnalysisContext): RuleViolation[] {
+    },
+  checkGlobalAuthentication(context: AnalysisContext): RuleViolation[] {
         const violations: RuleViolation[] = [];
 
         // Check for authentication middleware
@@ -318,9 +304,8 @@ export const authRequired: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
- private isAuthenticationMiddleware(file: any): boolean {
+    },
+  isAuthenticationMiddleware(file: any): boolean {
         const content = file.content.toLowerCase();
         const middlewarePatterns = [
             /auth.*middleware/,
@@ -333,9 +318,8 @@ export const authRequired: MCPSecurityRule = {
 
         return middlewarePatterns.some(pattern => pattern.test(content)) &&
             (content.includes('function') || content.includes('=>'));
-    }
-
- private hasAuthenticationConfig(file: any): boolean {
+    },
+  hasAuthenticationConfig(file: any): boolean {
         const content = file.content.toLowerCase();
         const configPatterns = [
             /auth.*config/,
@@ -346,9 +330,8 @@ export const authRequired: MCPSecurityRule = {
         ];
 
         return configPatterns.some(pattern => pattern.test(content));
-    }
-
- private checkAuthenticationImplementation(context: AnalysisContext): RuleViolation[] {
+    },
+  checkAuthenticationImplementation(context: AnalysisContext): RuleViolation[] {
         const violations: RuleViolation[] = [];
 
         for (const file of context.sourceFiles) {
@@ -368,9 +351,8 @@ export const authRequired: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
- private checkWeakAuthentication(file: any): RuleViolation[] {
+    },
+  checkWeakAuthentication(file: any): RuleViolation[] {
         const violations: RuleViolation[] = [];
 
         if (!file.ast) return violations;
@@ -424,9 +406,8 @@ export const authRequired: MCPSecurityRule = {
 
         visitor(file.ast);
         return violations;
-    }
-
- private isPasswordComparison(callText: string): boolean {
+    },
+  isPasswordComparison(callText: string): boolean {
         const passwordPatterns = [
             /password.*===/,
             /password.*==/,
@@ -437,9 +418,8 @@ export const authRequired: MCPSecurityRule = {
         ];
 
         return passwordPatterns.some(pattern => pattern.test(callText));
-    }
-
- private isWeakPasswordCheck(callText: string): boolean {
+    },
+  isWeakPasswordCheck(callText: string): boolean {
         // Check if it's NOT using proper hashing
         const strongHashPatterns = [
             /bcrypt/i,
@@ -449,9 +429,8 @@ export const authRequired: MCPSecurityRule = {
         ];
 
         return !strongHashPatterns.some(pattern => pattern.test(callText));
-    }
-
- private hasHardcodedCredentials(callText: string): boolean {
+    },
+  hasHardcodedCredentials(callText: string): boolean {
         const credentialPatterns = [
             /password.*=.*["'][^"']{8,}["']/,
             /secret.*=.*["'][^"']{16,}["']/,
@@ -460,9 +439,8 @@ export const authRequired: MCPSecurityRule = {
         ];
 
         return credentialPatterns.some(pattern => pattern.test(callText));
-    }
-
- private hasWeakJWTSecret(callText: string): boolean {
+    },
+  hasWeakJWTSecret(callText: string): boolean {
         if (!callText.toLowerCase().includes('jwt')) return false;
 
         const weakSecretPatterns = [
@@ -475,9 +453,8 @@ export const authRequired: MCPSecurityRule = {
         ];
 
         return weakSecretPatterns.some(pattern => pattern.test(callText));
-    }
-
- private checkAuthenticationBypass(file: any): RuleViolation[] {
+    },
+  checkAuthenticationBypass(file: any): RuleViolation[] {
         const violations: RuleViolation[] = [];
 
         if (!file.ast) return violations;
@@ -524,9 +501,8 @@ export const authRequired: MCPSecurityRule = {
 
         visitor(file.ast);
         return violations;
-    }
-
- private isAuthBypassCondition(condition: string): boolean {
+    },
+  isAuthBypassCondition(condition: string): boolean {
         const bypassPatterns = [
             /skip.*auth/i,
             /bypass.*auth/i,
@@ -537,9 +513,8 @@ export const authRequired: MCPSecurityRule = {
         ];
 
         return bypassPatterns.some(pattern => pattern.test(condition));
-    }
-
- private isDebugBypass(condition: string): boolean {
+    },
+  isDebugBypass(condition: string): boolean {
         const debugPatterns = [
             /debug.*mode/i,
             /dev.*mode/i,
@@ -550,9 +525,8 @@ export const authRequired: MCPSecurityRule = {
         ];
 
         return debugPatterns.some(pattern => pattern.test(condition));
-    }
-
- private checkCommentedAuth(node: ts.Node, file: any): RuleViolation[] {
+    },
+  checkCommentedAuth(node: ts.Node, file: any): RuleViolation[] {
         const violations: RuleViolation[] = [];
 
         // Get comments in the node range
@@ -576,9 +550,8 @@ export const authRequired: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
- private isCommentedAuthentication(commentText: string): boolean {
+    },
+  isCommentedAuthentication(commentText: string): boolean {
         const authPatterns = [
             /\/\/.*auth/i,
             /\/\*.*auth.*\*\//i,
@@ -588,9 +561,8 @@ export const authRequired: MCPSecurityRule = {
         ];
 
         return authPatterns.some(pattern => pattern.test(commentText));
-    }
-
- private checkCredentialHandling(file: any): RuleViolation[] {
+    },
+  checkCredentialHandling(file: any): RuleViolation[] {
         const violations: RuleViolation[] = [];
 
         if (!file.ast) return violations;
@@ -636,9 +608,8 @@ export const authRequired: MCPSecurityRule = {
 
         visitor(file.ast);
         return violations;
-    }
-
- private isCredentialVariable(nodeText: string): boolean {
+    },
+  isCredentialVariable(nodeText: string): boolean {
         const credentialPatterns = [
             /password/i,
             /secret/i,
@@ -649,9 +620,8 @@ export const authRequired: MCPSecurityRule = {
         ];
 
         return credentialPatterns.some(pattern => pattern.test(nodeText));
-    }
-
- private isInsecureCredentialHandling(nodeText: string): boolean {
+    },
+  isInsecureCredentialHandling(nodeText: string): boolean {
         const insecurePatterns = [
             /=.*["'][^"']+["']/,  // Direct assignment of string literals
             /console\./,          // Console output
@@ -662,9 +632,8 @@ export const authRequired: MCPSecurityRule = {
         ];
 
         return insecurePatterns.some(pattern => pattern.test(nodeText));
-    }
-
- private isLoggingCall(callText: string): boolean {
+    },
+  isLoggingCall(callText: string): boolean {
         const loggingPatterns = [
             /console\./,
             /log\./,
@@ -677,9 +646,8 @@ export const authRequired: MCPSecurityRule = {
         ];
 
         return loggingPatterns.some(pattern => pattern.test(callText));
-    }
-
- private mayLogCredentials(callText: string): boolean {
+    },
+  mayLogCredentials(callText: string): boolean {
         const credentialPatterns = [
             /password/i,
             /secret/i,
@@ -690,13 +658,11 @@ export const authRequired: MCPSecurityRule = {
         ];
 
         return credentialPatterns.some(pattern => pattern.test(callText));
-    }
-
- private getLineNumber(sourceFile: ts.SourceFile, node: ts.Node): number {
+    },
+  getLineNumber(sourceFile: ts.SourceFile, node: ts.Node): number {
         return sourceFile.getLineAndCharacterOfPosition(node.getStart()).line + 1;
-    }
-
- private getLineFromPosition(content: string, position: number): number {
+    },
+  getLineFromPosition(content: string, position: number): number {
         return content.substring(0, position).split('\n').length;
     }
-};
+} as MCPSecurityRule;

--- a/src/rules/authentication/role-validation.ts
+++ b/src/rules/authentication/role-validation.ts
@@ -1,7 +1,7 @@
 import { MCPSecurityRule, AnalysisContext, RuleViolation } from '../../core/types';
 import * as ts from 'typescript';
 
-export const roleValidation: MCPSecurityRule = {
+export const roleValidation = {
     id: 'role-validation',
     name: 'Role-Based Access Validation',
     description: 'Ensures proper role-based access control implementation in MCP tools',
@@ -33,9 +33,8 @@ export const roleValidation: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
-  private checkRoleSystem(context: AnalysisContext): RuleViolation[] {
+    },
+  checkRoleSystem(context: AnalysisContext): RuleViolation[] {
         const violations: RuleViolation[] = [];
 
         // Check for role definition
@@ -81,9 +80,8 @@ export const roleValidation: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
-  private hasRoleDefinitions(file: any): boolean {
+    },
+  hasRoleDefinitions(file: any): boolean {
         const content = file.content.toLowerCase();
         const rolePatterns = [
             /role.*=.*{/,
@@ -96,9 +94,8 @@ export const roleValidation: MCPSecurityRule = {
         ];
 
         return rolePatterns.some(pattern => pattern.test(content));
-    }
-
-  private hasRoleAssignment(file: any): boolean {
+    },
+  hasRoleAssignment(file: any): boolean {
         const content = file.content.toLowerCase();
         const assignmentPatterns = [
             /assign.*role/,
@@ -110,9 +107,8 @@ export const roleValidation: MCPSecurityRule = {
         ];
 
         return assignmentPatterns.some(pattern => pattern.test(content));
-    }
-
-  private hasRoleHierarchy(file: any): boolean {
+    },
+  hasRoleHierarchy(file: any): boolean {
         const content = file.content.toLowerCase();
         const hierarchyPatterns = [
             /role.*inherit/,
@@ -124,9 +120,8 @@ export const roleValidation: MCPSecurityRule = {
         ];
 
         return hierarchyPatterns.some(pattern => pattern.test(content));
-    }
-
-  private async checkToolRoleValidation(tool: any, context: AnalysisContext): Promise<RuleViolation[]> {
+    },
+  async checkToolRoleValidation(tool: any, context: AnalysisContext): Promise<RuleViolation[]> {
         const violations: RuleViolation[] = [];
 
         // Check if tool defines required roles
@@ -150,14 +145,12 @@ export const roleValidation: MCPSecurityRule = {
         violations.push(...implViolations);
 
         return violations;
-    }
-
-  private hasRequiredRoles(tool: any): boolean {
+    },
+  hasRequiredRoles(tool: any): boolean {
         return tool.roles &&
             (Array.isArray(tool.roles) ? tool.roles.length > 0 : typeof tool.roles === 'string');
-    }
-
-  private isHighPrivilegeTool(tool: any): boolean {
+    },
+  isHighPrivilegeTool(tool: any): boolean {
         const highPrivilegePatterns = [
             /admin/i,
             /system/i,
@@ -174,9 +167,8 @@ export const roleValidation: MCPSecurityRule = {
         return highPrivilegePatterns.some(pattern =>
             pattern.test(tool.name) || pattern.test(tool.description || '')
         );
-    }
-
-  private validateToolRoles(tool: any, context: AnalysisContext): RuleViolation[] {
+    },
+  validateToolRoles(tool: any, context: AnalysisContext): RuleViolation[] {
         const violations: RuleViolation[] = [];
         const roles = Array.isArray(tool.roles) ? tool.roles : [tool.roles];
 
@@ -216,15 +208,13 @@ export const roleValidation: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
-  private isValidRoleName(role: string): boolean {
+    },
+  isValidRoleName(role: string): boolean {
         // Standard role naming: lowercase, underscores, no spaces
         const rolePattern = /^[a-z][a-z0-9_]*$/;
         return rolePattern.test(role);
-    }
-
-  private isOverlyBroadRole(role: string): boolean {
+    },
+  isOverlyBroadRole(role: string): boolean {
         const broadRoles = [
             'admin',
             'administrator',
@@ -237,9 +227,8 @@ export const roleValidation: MCPSecurityRule = {
         ];
 
         return broadRoles.includes(role.toLowerCase());
-    }
-
-  private isFoxCorpCompliantRole(role: string): boolean {
+    },
+  isFoxCorpCompliantRole(role: string): boolean {
         const foxCorpStandardRoles = [
             'viewer',
             'editor',
@@ -254,9 +243,8 @@ export const roleValidation: MCPSecurityRule = {
         return foxCorpStandardRoles.includes(role.toLowerCase()) ||
             role.startsWith('fox_') ||
             role.startsWith('content_');
-    }
-
-  private async checkRoleImplementation(tool: any, context: AnalysisContext): Promise<RuleViolation[]> {
+    },
+  async checkRoleImplementation(tool: any, context: AnalysisContext): Promise<RuleViolation[]> {
         const violations: RuleViolation[] = [];
 
         // Find tool implementation
@@ -303,9 +291,8 @@ export const roleValidation: MCPSecurityRule = {
         violations.push(...escalationViolations);
 
         return violations;
-    }
-
-  private hasRoleValidationCode(file: any): boolean {
+    },
+  hasRoleValidationCode(file: any): boolean {
         const content = file.content.toLowerCase();
         const roleValidationPatterns = [
             /check.*role/,
@@ -319,9 +306,8 @@ export const roleValidation: MCPSecurityRule = {
         ];
 
         return roleValidationPatterns.some(pattern => pattern.test(content));
-    }
-
-  private hasRoleErrorHandling(file: any): boolean {
+    },
+  hasRoleErrorHandling(file: any): boolean {
         const content = file.content.toLowerCase();
         const errorPatterns = [
             /role.*error/,
@@ -334,9 +320,8 @@ export const roleValidation: MCPSecurityRule = {
         ];
 
         return errorPatterns.some(pattern => pattern.test(content));
-    }
-
-  private checkRoleEscalation(file: any, tool: any): RuleViolation[] {
+    },
+  checkRoleEscalation(file: any, tool: any): RuleViolation[] {
         const violations: RuleViolation[] = [];
 
         if (!file.ast) return violations;
@@ -393,9 +378,8 @@ export const roleValidation: MCPSecurityRule = {
 
         visitor(file.ast);
         return violations;
-    }
-
-  private isRoleModification(callText: string): boolean {
+    },
+  isRoleModification(callText: string): boolean {
         const modificationPatterns = [
             /add.*role/i,
             /remove.*role/i,
@@ -408,9 +392,8 @@ export const roleValidation: MCPSecurityRule = {
         ];
 
         return modificationPatterns.some(pattern => pattern.test(callText));
-    }
-
-  private isRoleBypass(callText: string): boolean {
+    },
+  isRoleBypass(callText: string): boolean {
         const bypassPatterns = [
             /skip.*role/i,
             /bypass.*role/i,
@@ -420,9 +403,8 @@ export const roleValidation: MCPSecurityRule = {
         ];
 
         return bypassPatterns.some(pattern => pattern.test(callText));
-    }
-
-  private isRoleBypassCondition(condition: string): boolean {
+    },
+  isRoleBypassCondition(condition: string): boolean {
         const bypassPatterns = [
             /!.*role/i,
             /role.*===.*null/i,
@@ -433,9 +415,8 @@ export const roleValidation: MCPSecurityRule = {
         ];
 
         return bypassPatterns.some(pattern => pattern.test(condition));
-    }
-
-  private checkRoleBasedResourceAccess(context: AnalysisContext): RuleViolation[] {
+    },
+  checkRoleBasedResourceAccess(context: AnalysisContext): RuleViolation[] {
         const violations: RuleViolation[] = [];
 
         // Check if resources use role-based access
@@ -452,15 +433,13 @@ export const roleValidation: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
-  private hasRoleBasedAccess(resource: any): boolean {
+    },
+  hasRoleBasedAccess(resource: any): boolean {
         return resource.roles ||
             resource.accessControl?.roles ||
             resource.permissions?.some((perm: string) => perm.includes('role'));
-    }
-
-  private checkFoxCorpRoles(context: AnalysisContext): RuleViolation[] {
+    },
+  checkFoxCorpRoles(context: AnalysisContext): RuleViolation[] {
         const violations: RuleViolation[] = [];
 
         // Check for Fox Corp specific role requirements
@@ -498,9 +477,8 @@ export const roleValidation: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
-  private isStreamingTool(tool: any): boolean {
+    },
+  isStreamingTool(tool: any): boolean {
         const streamingPatterns = [
             /stream/i,
             /video/i,
@@ -513,9 +491,8 @@ export const roleValidation: MCPSecurityRule = {
         return streamingPatterns.some(pattern =>
             pattern.test(tool.name) || pattern.test(tool.description || '')
         );
-    }
-
-  private hasStreamingRoles(tool: any): boolean {
+    },
+  hasStreamingRoles(tool: any): boolean {
         const streamingRoles = [
             'stream_operator',
             'content_manager',
@@ -525,9 +502,8 @@ export const roleValidation: MCPSecurityRule = {
 
         const toolRoles = Array.isArray(tool.roles) ? tool.roles : [tool.roles];
         return streamingRoles.some(role => toolRoles.includes(role));
-    }
-
- private isAdminTool(tool: any): boolean {
+    },
+  isAdminTool(tool: any): boolean {
         const adminPatterns = [
             /admin/i,
             /manage/i,
@@ -540,9 +516,8 @@ export const roleValidation: MCPSecurityRule = {
         return adminPatterns.some(pattern =>
             pattern.test(tool.name) || pattern.test(tool.description || '')
         );
-    }
-
- private hasOperationalRoles(tool: any): boolean {
+    },
+  hasOperationalRoles(tool: any): boolean {
         const operationalRoles = [
             'viewer',
             'editor',
@@ -553,9 +528,8 @@ export const roleValidation: MCPSecurityRule = {
 
         const toolRoles = Array.isArray(tool.roles) ? tool.roles : [tool.roles];
         return operationalRoles.some(role => toolRoles.includes(role));
-    }
-
- private getLineNumber(sourceFile: ts.SourceFile, node: ts.Node): number {
+    },
+  getLineNumber(sourceFile: ts.SourceFile, node: ts.Node): number {
         return sourceFile.getLineAndCharacterOfPosition(node.getStart()).line + 1;
     }
-};
+} as MCPSecurityRule;

--- a/src/rules/authorization/permission-checks.ts
+++ b/src/rules/authorization/permission-checks.ts
@@ -1,7 +1,7 @@
 import { MCPSecurityRule, AnalysisContext, RuleViolation } from '../../core/types';
 import * as ts from 'typescript';
 
-export const permissionChecks: MCPSecurityRule = {
+export const permissionChecks = {
     id: 'permission-checks',
     name: 'Permission Checks',
     description: 'Ensures proper permission validation before tool execution',
@@ -23,9 +23,8 @@ export const permissionChecks: MCPSecurityRule = {
         violations.push(...systemViolations);
 
         return violations;
-    }
-
-  private async checkToolPermissions(tool: any, context: AnalysisContext): Promise<RuleViolation[]> {
+    },
+  async checkToolPermissions(tool: any, context: AnalysisContext): Promise<RuleViolation[]> {
         const violations: RuleViolation[] = [];
 
         // Check if tool has defined permissions
@@ -52,9 +51,8 @@ export const permissionChecks: MCPSecurityRule = {
         violations.push(...escalationViolations);
 
         return violations;
-    }
-
-  private validatePermissionFormat(tool: any, context: AnalysisContext): RuleViolation[] {
+    },
+  validatePermissionFormat(tool: any, context: AnalysisContext): RuleViolation[] {
         const violations: RuleViolation[] = [];
 
         for (const permission of tool.permissions) {
@@ -88,15 +86,13 @@ export const permissionChecks: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
-  private isValidPermissionFormat(permission: string): boolean {
+    },
+  isValidPermissionFormat(permission: string): boolean {
         // Standard format: resource:action
         const permissionPattern = /^[a-z][a-z0-9-]*:[a-z][a-z0-9-]*$/;
         return permissionPattern.test(permission);
-    }
-
-  private isOverlyBroadPermission(permission: string): boolean {
+    },
+  isOverlyBroadPermission(permission: string): boolean {
         const broadPatterns = [
             /.*:\*/,      // Any action wildcard
             /\*:.*/,      // Any resource wildcard
@@ -107,9 +103,8 @@ export const permissionChecks: MCPSecurityRule = {
         ];
 
         return broadPatterns.some(pattern => pattern.test(permission));
-    }
-
-  private isStreamingPermission(permission: string): boolean {
+    },
+  isStreamingPermission(permission: string): boolean {
         const streamingPatterns = [
             /stream/i,
             /media/i,
@@ -119,9 +114,8 @@ export const permissionChecks: MCPSecurityRule = {
         ];
 
         return streamingPatterns.some(pattern => pattern.test(permission));
-    }
-
-  private validateStreamingPermission(tool: any, permission: string, context: AnalysisContext): RuleViolation[] {
+    },
+  validateStreamingPermission(tool: any, permission: string, context: AnalysisContext): RuleViolation[] {
         const violations: RuleViolation[] = [];
 
         // Fox Corp streaming permissions must be specific
@@ -150,9 +144,8 @@ export const permissionChecks: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
-  private async checkPermissionImplementation(tool: any, context: AnalysisContext): Promise<RuleViolation[]> {
+    },
+  async checkPermissionImplementation(tool: any, context: AnalysisContext): Promise<RuleViolation[]> {
         const violations: RuleViolation[] = [];
 
         // Find tool implementation
@@ -209,9 +202,8 @@ export const permissionChecks: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
-  private hasPermissionValidation(file: any): boolean {
+    },
+  hasPermissionValidation(file: any): boolean {
         const content = file.content.toLowerCase();
         const permissionPatterns = [
             /check.*permission/,
@@ -225,9 +217,8 @@ export const permissionChecks: MCPSecurityRule = {
         ];
 
         return permissionPatterns.some(pattern => pattern.test(content));
-    }
-
-  private hasPermissionErrorHandling(file: any): boolean {
+    },
+  hasPermissionErrorHandling(file: any): boolean {
         const content = file.content.toLowerCase();
         const errorPatterns = [
             /403/,  // Forbidden status code
@@ -240,9 +231,8 @@ export const permissionChecks: MCPSecurityRule = {
         ];
 
         return errorPatterns.some(pattern => pattern.test(content));
-    }
-
-  private hasContextBasedValidation(file: any): boolean {
+    },
+  hasContextBasedValidation(file: any): boolean {
         const content = file.content.toLowerCase();
         const contextPatterns = [
             /user.*permission/,
@@ -255,9 +245,8 @@ export const permissionChecks: MCPSecurityRule = {
         ];
 
         return contextPatterns.some(pattern => pattern.test(content));
-    }
-
-  private requiresContextValidation(tool: any): boolean {
+    },
+  requiresContextValidation(tool: any): boolean {
         // Tools that modify data or access sensitive resources need context validation
         const sensitivePatterns = [
             /write/i,
@@ -277,9 +266,8 @@ export const permissionChecks: MCPSecurityRule = {
             pattern.test(tool.description || '') ||
             (tool.permissions && tool.permissions.some((perm: string) => pattern.test(perm)))
         );
-    }
-
-  private async checkPrivilegeEscalation(tool: any, context: AnalysisContext): Promise<RuleViolation[]> {
+    },
+  async checkPrivilegeEscalation(tool: any, context: AnalysisContext): Promise<RuleViolation[]> {
         const violations: RuleViolation[] = [];
 
         const implFile = context.sourceFiles.find(file =>
@@ -343,9 +331,8 @@ export const permissionChecks: MCPSecurityRule = {
 
         visitor(implFile.ast);
         return violations;
-    }
-
-  private isPermissionModification(callText: string): boolean {
+    },
+  isPermissionModification(callText: string): boolean {
         const modificationPatterns = [
             /set.*permission/i,
             /grant.*permission/i,
@@ -358,9 +345,8 @@ export const permissionChecks: MCPSecurityRule = {
         ];
 
         return modificationPatterns.some(pattern => pattern.test(callText));
-    }
-
-  private isSudoCall(callText: string): boolean {
+    },
+  isSudoCall(callText: string): boolean {
         const sudoPatterns = [
             /sudo/i,
             /runas/i,
@@ -371,9 +357,8 @@ export const permissionChecks: MCPSecurityRule = {
         ];
 
         return sudoPatterns.some(pattern => pattern.test(callText));
-    }
-
-  private isPermissionBypass(condition: string): boolean {
+    },
+  isPermissionBypass(condition: string): boolean {
         const bypassPatterns = [
             /skip.*permission/i,
             /bypass.*auth/i,
@@ -384,9 +369,8 @@ export const permissionChecks: MCPSecurityRule = {
         ];
 
         return bypassPatterns.some(pattern => pattern.test(condition));
-    }
-
-  private checkPermissionSystem(context: AnalysisContext): RuleViolation[] {
+    },
+  checkPermissionSystem(context: AnalysisContext): RuleViolation[] {
         const violations: RuleViolation[] = [];
 
         // Check for permission system implementation
@@ -422,9 +406,8 @@ export const permissionChecks: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
-  private getLineNumber(sourceFile: ts.SourceFile, node: ts.Node): number {
+    },
+  getLineNumber(sourceFile: ts.SourceFile, node: ts.Node): number {
         return sourceFile.getLineAndCharacterOfPosition(node.getStart()).line + 1;
     }
-};
+} as MCPSecurityRule;

--- a/src/rules/authorization/resource-access.ts
+++ b/src/rules/authorization/resource-access.ts
@@ -1,7 +1,7 @@
 import { MCPSecurityRule, AnalysisContext, RuleViolation } from '../../core/types';
 import * as ts from 'typescript';
 
-export const resourceAccess: MCPSecurityRule = {
+export const resourceAccess = {
     id: 'resource-access',
     name: 'Resource Access Control',
     description: 'Validates proper access controls for MCP resources and sensitive data',
@@ -37,9 +37,8 @@ export const resourceAccess: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
-  private async checkResourceAccess(resource: any, context: AnalysisContext): Promise<RuleViolation[]> {
+    },
+  async checkResourceAccess(resource: any, context: AnalysisContext): Promise<RuleViolation[]> {
         const violations: RuleViolation[] = [];
 
         // Check if resource has access control metadata
@@ -75,9 +74,8 @@ export const resourceAccess: MCPSecurityRule = {
         violations.push(...implViolations);
 
         return violations;
-    }
-
- private isSensitiveResource(resource: any): boolean {
+    },
+  isSensitiveResource(resource: any): boolean {
         const sensitivePatterns = [
             /config/i,
             /secret/i,
@@ -99,17 +97,15 @@ export const resourceAccess: MCPSecurityRule = {
             pattern.test(resource.uri) ||
             pattern.test(resource.type || '')
         );
-    }
-
- private getResourceType(resource: any): string {
+    },
+  getResourceType(resource: any): string {
         if (resource.uri.includes('file://')) return 'file';
         if (resource.uri.includes('http://') || resource.uri.includes('https://')) return 'web';
         if (resource.uri.includes('db://') || resource.uri.includes('database://')) return 'database';
         if (resource.uri.includes('stream://')) return 'streaming';
         return 'unknown';
-    }
-
- private validateResourceURI(resource: any): RuleViolation[] {
+    },
+  validateResourceURI(resource: any): RuleViolation[] {
         const violations: RuleViolation[] = [];
         const uri = resource.uri;
 
@@ -158,9 +154,8 @@ export const resourceAccess: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
- private isInternalURI(uri: string): boolean {
+    },
+  isInternalURI(uri: string): boolean {
         const internalPatterns = [
             /localhost/i,
             /127\.0\.0\.1/,
@@ -172,15 +167,13 @@ export const resourceAccess: MCPSecurityRule = {
         ];
 
         return internalPatterns.some(pattern => pattern.test(uri));
-    }
-
- private hasProperInternalAccess(resource: any): boolean {
+    },
+  hasProperInternalAccess(resource: any): boolean {
         return resource.accessControl &&
             (resource.accessControl.level === 'restricted' ||
                 resource.accessControl.internal === true);
-    }
-
- private hasPathTraversal(uri: string): boolean {
+    },
+  hasPathTraversal(uri: string): boolean {
         const traversalPatterns = [
             /\.\.\//,
             /\.\.\\/,
@@ -189,9 +182,8 @@ export const resourceAccess: MCPSecurityRule = {
         ];
 
         return traversalPatterns.some(pattern => pattern.test(uri));
-    }
-
- private hasCredentialsInURI(uri: string): boolean {
+    },
+  hasCredentialsInURI(uri: string): boolean {
         const credentialPatterns = [
             /:\/\/[^:@]+:[^@]+@/,  // username:password@
             /api[_-]?key=/i,
@@ -201,9 +193,8 @@ export const resourceAccess: MCPSecurityRule = {
         ];
 
         return credentialPatterns.some(pattern => pattern.test(uri));
-    }
-
- private async checkResourceImplementation(resource: any, context: AnalysisContext): Promise<RuleViolation[]> {
+    },
+  async checkResourceImplementation(resource: any, context: AnalysisContext): Promise<RuleViolation[]> {
         const violations: RuleViolation[] = [];
 
         // Find files that handle this resource
@@ -241,9 +232,8 @@ export const resourceAccess: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
- private checkFileSystemAccess(context: AnalysisContext): RuleViolation[] {
+    },
+  checkFileSystemAccess(context: AnalysisContext): RuleViolation[] {
         const violations: RuleViolation[] = [];
 
         for (const file of context.sourceFiles) {
@@ -267,9 +257,8 @@ export const resourceAccess: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
- private isFileSystemOperation(callText: string): boolean {
+    },
+  isFileSystemOperation(callText: string): boolean {
         const fsPatterns = [
             /fs\.(read|write|unlink|mkdir|rmdir)/,
             /readFile/,
@@ -281,9 +270,8 @@ export const resourceAccess: MCPSecurityRule = {
         ];
 
         return fsPatterns.some(pattern => pattern.test(callText));
-    }
-
- private analyzeFileSystemCall(node: ts.CallExpression, file: any, callText: string): RuleViolation[] {
+    },
+  analyzeFileSystemCall(node: ts.CallExpression, file: any, callText: string): RuleViolation[] {
         const violations: RuleViolation[] = [];
 
         // Check for path validation
@@ -313,9 +301,8 @@ export const resourceAccess: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
- private hasPathValidation(callText: string, file: any): boolean {
+    },
+  hasPathValidation(callText: string, file: any): boolean {
         // Look for path validation in surrounding context
         const context = this.getCallContext(callText, file);
         const validationPatterns = [
@@ -328,16 +315,14 @@ export const resourceAccess: MCPSecurityRule = {
         ];
 
         return validationPatterns.some(pattern => pattern.test(context));
-    }
-
- private getCallContext(callText: string, file: any): string {
+    },
+  getCallContext(callText: string, file: any): string {
         const callIndex = file.content.indexOf(callText);
         const start = Math.max(0, callIndex - 200);
         const end = Math.min(file.content.length, callIndex + 200);
         return file.content.substring(start, end);
-    }
-
- private isWriteToSensitiveDirectory(callText: string): boolean {
+    },
+  isWriteToSensitiveDirectory(callText: string): boolean {
         const sensitivePatterns = [
             /\/etc\//,
             /\/root\//,
@@ -348,9 +333,8 @@ export const resourceAccess: MCPSecurityRule = {
         ];
 
         return sensitivePatterns.some(pattern => pattern.test(callText));
-    }
-
- private checkDatabaseAccess(context: AnalysisContext): RuleViolation[] {
+    },
+  checkDatabaseAccess(context: AnalysisContext): RuleViolation[] {
         const violations: RuleViolation[] = [];
 
         for (const file of context.sourceFiles) {
@@ -374,9 +358,8 @@ export const resourceAccess: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
- private isDatabaseOperation(callText: string): boolean {
+    },
+  isDatabaseOperation(callText: string): boolean {
         const dbPatterns = [
             /\.query\(/,
             /\.execute\(/,
@@ -392,9 +375,8 @@ export const resourceAccess: MCPSecurityRule = {
         ];
 
         return dbPatterns.some(pattern => pattern.test(callText));
-    }
-
- private analyzeDatabaseCall(node: ts.CallExpression, file: any, callText: string): RuleViolation[] {
+    },
+  analyzeDatabaseCall(node: ts.CallExpression, file: any, callText: string): RuleViolation[] {
         const violations: RuleViolation[] = [];
 
         // Check for parameterized queries
@@ -424,9 +406,8 @@ export const resourceAccess: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
- private isRawSQLQuery(callText: string): boolean {
+    },
+  isRawSQLQuery(callText: string): boolean {
         const sqlPatterns = [
             /SELECT.*FROM/i,
             /INSERT.*INTO/i,
@@ -435,9 +416,8 @@ export const resourceAccess: MCPSecurityRule = {
         ];
 
         return sqlPatterns.some(pattern => pattern.test(callText));
-    }
-
- private isParameterized(callText: string): boolean {
+    },
+  isParameterized(callText: string): boolean {
         const paramPatterns = [
             /\$\d+/,  // PostgreSQL style $1, $2
             /\?/,     // MySQL/SQLite style ?
@@ -445,9 +425,8 @@ export const resourceAccess: MCPSecurityRule = {
         ];
 
         return paramPatterns.some(pattern => pattern.test(callText));
-    }
-
- private hasDBAccessControl(callText: string, file: any): boolean {
+    },
+  hasDBAccessControl(callText: string, file: any): boolean {
         const context = this.getCallContext(callText, file);
         const accessPatterns = [
             /check.*permission/i,
@@ -458,9 +437,8 @@ export const resourceAccess: MCPSecurityRule = {
         ];
 
         return accessPatterns.some(pattern => pattern.test(context));
-    }
-
- private checkNetworkAccess(context: AnalysisContext): RuleViolation[] {
+    },
+  checkNetworkAccess(context: AnalysisContext): RuleViolation[] {
         const violations: RuleViolation[] = [];
 
         for (const file of context.sourceFiles) {
@@ -484,9 +462,8 @@ export const resourceAccess: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
- private isNetworkOperation(callText: string): boolean {
+    },
+  isNetworkOperation(callText: string): boolean {
         const networkPatterns = [
             /fetch\(/,
             /axios\./,
@@ -500,9 +477,8 @@ export const resourceAccess: MCPSecurityRule = {
         ];
 
         return networkPatterns.some(pattern => pattern.test(callText));
-    }
-
- private analyzeNetworkCall(node: ts.CallExpression, file: any, callText: string): RuleViolation[] {
+    },
+  analyzeNetworkCall(node: ts.CallExpression, file: any, callText: string): RuleViolation[] {
         const violations: RuleViolation[] = [];
 
         // Check for URL validation
@@ -532,9 +508,8 @@ export const resourceAccess: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
- private hasURLValidation(callText: string, file: any): boolean {
+    },
+  hasURLValidation(callText: string, file: any): boolean {
         const context = this.getCallContext(callText, file);
         const validationPatterns = [
             /validate.*url/i,
@@ -545,9 +520,8 @@ export const resourceAccess: MCPSecurityRule = {
         ];
 
         return validationPatterns.some(pattern => pattern.test(context));
-    }
-
- private maybeSSRFVulnerable(callText: string): boolean {
+    },
+  maybeSSRFVulnerable(callText: string): boolean {
         // Check if URL comes from user input without validation
         const userInputPatterns = [
             /params\./,
@@ -557,9 +531,8 @@ export const resourceAccess: MCPSecurityRule = {
         ];
 
         return userInputPatterns.some(pattern => pattern.test(callText));
-    }
-
- private checkStreamingResourceAccess(context: AnalysisContext): RuleViolation[] {
+    },
+  checkStreamingResourceAccess(context: AnalysisContext): RuleViolation[] {
         const violations: RuleViolation[] = [];
 
         // Check for streaming-specific resources
@@ -603,9 +576,8 @@ export const resourceAccess: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
- private isStreamingResource(resource: any): boolean {
+    },
+  isStreamingResource(resource: any): boolean {
         const streamingPatterns = [
             /stream/i,
             /video/i,
@@ -622,9 +594,8 @@ export const resourceAccess: MCPSecurityRule = {
             pattern.test(resource.uri) ||
             pattern.test(resource.type || '')
         );
-    }
-
- private hasDRMProtection(resource: any): boolean {
+    },
+  hasDRMProtection(resource: any): boolean {
         const drmPatterns = [
             /drm/i,
             /fairplay/i,
@@ -636,9 +607,8 @@ export const resourceAccess: MCPSecurityRule = {
 
         const resourceText = JSON.stringify(resource).toLowerCase();
         return drmPatterns.some(pattern => pattern.test(resourceText));
-    }
-
- private hasGeoBlocking(resource: any): boolean {
+    },
+  hasGeoBlocking(resource: any): boolean {
         const geoPatterns = [
             /geo/i,
             /region/i,
@@ -650,9 +620,8 @@ export const resourceAccess: MCPSecurityRule = {
 
         const resourceText = JSON.stringify(resource).toLowerCase();
         return geoPatterns.some(pattern => pattern.test(resourceText));
-    }
-
- private hasWatermarking(resource: any): boolean {
+    },
+  hasWatermarking(resource: any): boolean {
         const watermarkPatterns = [
             /watermark/i,
             /forensic/i,
@@ -662,9 +631,8 @@ export const resourceAccess: MCPSecurityRule = {
 
         const resourceText = JSON.stringify(resource).toLowerCase();
         return watermarkPatterns.some(pattern => pattern.test(resourceText));
-    }
-
- private hasAccessControlCheck(file: any): boolean {
+    },
+  hasAccessControlCheck(file: any): boolean {
         const content = file.content.toLowerCase();
         const accessPatterns = [
             /check.*access/i,
@@ -676,9 +644,8 @@ export const resourceAccess: MCPSecurityRule = {
         ];
 
         return accessPatterns.some(pattern => pattern.test(content));
-    }
-
- private hasSecureErrorHandling(file: any): boolean {
+    },
+  hasSecureErrorHandling(file: any): boolean {
         const content = file.content.toLowerCase();
         const secureErrorPatterns = [
             /generic.*error/i,
@@ -698,9 +665,8 @@ export const resourceAccess: MCPSecurityRule = {
         const hasInsecure = insecureErrorPatterns.some(pattern => pattern.test(content));
 
         return hasSecure && !hasInsecure;
-    }
-
- private getLineNumber(sourceFile: ts.SourceFile, node: ts.Node): number {
+    },
+  getLineNumber(sourceFile: ts.SourceFile, node: ts.Node): number {
         return sourceFile.getLineAndCharacterOfPosition(node.getStart()).line + 1;
     }
-};
+} as MCPSecurityRule;

--- a/src/rules/fox-streaming/streaming-protection.ts
+++ b/src/rules/fox-streaming/streaming-protection.ts
@@ -1,7 +1,7 @@
 import { MCPSecurityRule, AnalysisContext, RuleViolation } from '../../core/types';
 import * as ts from 'typescript';
 
-export const foxStreamingProtection: MCPSecurityRule = {
+export const foxStreamingProtection = {
   id: 'fox-streaming-protection',
   name: 'Fox Streaming Asset Protection',
   description: 'Ensures streaming assets and IP are protected with appropriate access controls',
@@ -51,9 +51,8 @@ export const foxStreamingProtection: MCPSecurityRule = {
     }
 
     return violations;
-  }
-
-  private async analyzeStreamingImplementation(tool: any, context: AnalysisContext): Promise<RuleViolation[]> {
+  },
+  async analyzeStreamingImplementation(tool: any, context: AnalysisContext): Promise<RuleViolation[]> {
     const violations: RuleViolation[] = [];
     
     // Find the implementation file
@@ -103,9 +102,8 @@ export const foxStreamingProtection: MCPSecurityRule = {
 
     visitor(implFile.ast);
     return violations;
-  }
-
-  private isStreamingUrl(url: string): boolean {
+  },
+  isStreamingUrl(url: string): boolean {
     const streamingPatterns = [
       /rtmp:\/\//i,
       /hls:\/\//i,
@@ -117,18 +115,16 @@ export const foxStreamingProtection: MCPSecurityRule = {
     ];
     
     return streamingPatterns.some(pattern => pattern.test(url));
-  }
-
-  private hasProperValidation(content: string, url: string): boolean {
+  },
+  hasProperValidation(content: string, url: string): boolean {
     const context = content.substring(
       Math.max(0, content.indexOf(url) - 200),
       content.indexOf(url) + 200
     );
     
     return /validate|sanitize|allowlist|whitelist/i.test(context);
-  }
-
-  private containsCredentials(value: string): boolean {
+  },
+  containsCredentials(value: string): boolean {
     const credentialPatterns = [
       /api[_-]?key/i,
       /secret/i,
@@ -140,9 +136,8 @@ export const foxStreamingProtection: MCPSecurityRule = {
     return credentialPatterns.some(pattern => pattern.test(value)) && 
            value.length > 10 && 
            /[a-zA-Z0-9]{8,}/.test(value);
-  }
-
-  private getLineNumber(sourceFile: ts.SourceFile, node: ts.Node): number {
+  },
+  getLineNumber(sourceFile: ts.SourceFile, node: ts.Node): number {
     return sourceFile.getLineAndCharacterOfPosition(node.getStart()).line + 1;
   }
-};
+} as MCPSecurityRule;

--- a/src/rules/input-validation/injection-detection.ts
+++ b/src/rules/input-validation/injection-detection.ts
@@ -1,7 +1,7 @@
 import { MCPSecurityRule, AnalysisContext, RuleViolation } from '../../core/types';
 import * as ts from 'typescript';
 
-export const injectionDetection: MCPSecurityRule = {
+export const injectionDetection = {
   id: 'injection-detection',
   name: 'Injection Attack Detection',
   description: 'Detects potential injection vulnerabilities in MCP tool implementations',
@@ -20,9 +20,8 @@ export const injectionDetection: MCPSecurityRule = {
     }
 
     return violations;
-  }
-
-  private analyzeFileForInjections(file: any, context: AnalysisContext): RuleViolation[] {
+  },
+  analyzeFileForInjections(file: any, context: AnalysisContext): RuleViolation[] {
     const violations: RuleViolation[] = [];
     
     const visitor = (node: ts.Node) => {
@@ -43,9 +42,8 @@ export const injectionDetection: MCPSecurityRule = {
 
     visitor(file.ast);
     return violations;
-  }
-
-  private checkSQLInjection(node: ts.CallExpression, file: any, violations: RuleViolation[]) {
+  },
+  checkSQLInjection(node: ts.CallExpression, file: any, violations: RuleViolation[]) {
     const expression = node.expression;
     
     if (ts.isPropertyAccessExpression(expression) && 
@@ -69,9 +67,8 @@ export const injectionDetection: MCPSecurityRule = {
         }
       }
     }
-  }
-
-  private checkCommandInjection(node: ts.CallExpression, file: any, violations: RuleViolation[]) {
+  },
+  checkCommandInjection(node: ts.CallExpression, file: any, violations: RuleViolation[]) {
     const expression = node.expression;
     
     if (ts.isIdentifier(expression) && 
@@ -90,9 +87,8 @@ export const injectionDetection: MCPSecurityRule = {
         });
       }
     }
-  }
-
-  private checkEvalInjection(node: ts.CallExpression, file: any, violations: RuleViolation[]) {
+  },
+  checkEvalInjection(node: ts.CallExpression, file: any, violations: RuleViolation[]) {
     const expression = node.expression;
     
     if (ts.isIdentifier(expression) && 
@@ -108,9 +104,8 @@ export const injectionDetection: MCPSecurityRule = {
         fix: 'Avoid eval-like functions or use safer alternatives'
       });
     }
-  }
-
-  private checkTemplateLiteralInjection(node: ts.TemplateExpression, file: any, violations: RuleViolation[]) {
+  },
+  checkTemplateLiteralInjection(node: ts.TemplateExpression, file: any, violations: RuleViolation[]) {
     // Check if template literal contains SQL-like or command-like patterns
     const spans = node.templateSpans;
     
@@ -131,9 +126,8 @@ export const injectionDetection: MCPSecurityRule = {
         }
       }
     }
-  }
-
-  private containsUnsanitizedInput(node: ts.Node, file: any): boolean {
+  },
+  containsUnsanitizedInput(node: ts.Node, file: any): boolean {
     // Simple heuristic: check if the node references user input without sanitization
     const text = node.getText(file.ast);
     
@@ -157,13 +151,11 @@ export const injectionDetection: MCPSecurityRule = {
     const hasSanitization = sanitizationPatterns.some(pattern => pattern.test(text));
 
     return hasUserInput && !hasSanitization;
-  }
-
-  private getTemplateContext(node: ts.TemplateExpression, file: any): string {
+  },
+  getTemplateContext(node: ts.TemplateExpression, file: any): string {
     return node.getText(file.ast);
-  }
-
-  private looksLikeSQLOrCommand(template: string): boolean {
+  },
+  looksLikeSQLOrCommand(template: string): boolean {
     const sqlPatterns = [
       /SELECT\s+.*\s+FROM/i,
       /INSERT\s+INTO/i,
@@ -180,9 +172,8 @@ export const injectionDetection: MCPSecurityRule = {
     ];
 
     return [...sqlPatterns, ...commandPatterns].some(pattern => pattern.test(template));
-  }
-
-  private getLineNumber(sourceFile: ts.SourceFile, node: ts.Node): number {
+  },
+  getLineNumber(sourceFile: ts.SourceFile, node: ts.Node): number {
     return sourceFile.getLineAndCharacterOfPosition(node.getStart()).line + 1;
   }
-};
+} as MCPSecurityRule;

--- a/src/rules/input-validation/parameter-validation.ts
+++ b/src/rules/input-validation/parameter-validation.ts
@@ -1,7 +1,7 @@
 import { MCPSecurityRule, AnalysisContext, RuleViolation } from '../../core/types';
 import * as ts from 'typescript';
 
-export const parameterValidation: MCPSecurityRule = {
+export const parameterValidation = {
     id: 'parameter-validation',
     name: 'Parameter Validation',
     description: 'Ensures all tool parameters are properly validated according to their schemas',
@@ -23,9 +23,8 @@ export const parameterValidation: MCPSecurityRule = {
         violations.push(...schemaViolations);
 
         return violations;
-    }
-
-  private async checkToolParameterValidation(tool: any, context: AnalysisContext): Promise<RuleViolation[]> {
+    },
+  async checkToolParameterValidation(tool: any, context: AnalysisContext): Promise<RuleViolation[]> {
         const violations: RuleViolation[] = [];
 
         // Check if tool has input schema
@@ -49,9 +48,8 @@ export const parameterValidation: MCPSecurityRule = {
         violations.push(...implViolations);
 
         return violations;
-    }
-
-  private validateSchemaStructure(tool: any, context: AnalysisContext): RuleViolation[] {
+    },
+  validateSchemaStructure(tool: any, context: AnalysisContext): RuleViolation[] {
         const violations: RuleViolation[] = [];
         const schema = tool.inputSchema;
 
@@ -91,9 +89,8 @@ export const parameterValidation: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
-  private validatePropertySchema(toolName: string, propName: string, propSchema: any): RuleViolation[] {
+    },
+  validatePropertySchema(toolName: string, propName: string, propSchema: any): RuleViolation[] {
         const violations: RuleViolation[] = [];
 
         // Check for missing type
@@ -132,9 +129,8 @@ export const parameterValidation: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
-  private validateStringSchema(toolName: string, propName: string, propSchema: any): RuleViolation[] {
+    },
+  validateStringSchema(toolName: string, propName: string, propSchema: any): RuleViolation[] {
         const violations: RuleViolation[] = [];
 
         // Check for length constraints
@@ -186,9 +182,8 @@ export const parameterValidation: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
- private validateNumberSchema(toolName: string, propName: string, propSchema: any): RuleViolation[] {
+    },
+  validateNumberSchema(toolName: string, propName: string, propSchema: any): RuleViolation[] {
         const violations: RuleViolation[] = [];
 
         // Check for range constraints
@@ -225,9 +220,8 @@ export const parameterValidation: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
- private validateArraySchema(toolName: string, propName: string, propSchema: any): RuleViolation[] {
+    },
+  validateArraySchema(toolName: string, propName: string, propSchema: any): RuleViolation[] {
         const violations: RuleViolation[] = [];
 
         // Check for items schema
@@ -264,9 +258,8 @@ export const parameterValidation: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
- private validateObjectSchema(toolName: string, propName: string, propSchema: any): RuleViolation[] {
+    },
+  validateObjectSchema(toolName: string, propName: string, propSchema: any): RuleViolation[] {
         const violations: RuleViolation[] = [];
 
         // Check for properties definition
@@ -303,9 +296,8 @@ export const parameterValidation: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
- private isDangerousEnumValue(value: string): boolean {
+    },
+  isDangerousEnumValue(value: string): boolean {
         const dangerousPatterns = [
             /\.\./,           // Path traversal
             /script/i,        // Script injection
@@ -318,9 +310,8 @@ export const parameterValidation: MCPSecurityRule = {
         ];
 
         return dangerousPatterns.some(pattern => pattern.test(value));
-    }
-
- private isSensitiveField(fieldName: string): boolean {
+    },
+  isSensitiveField(fieldName: string): boolean {
         const sensitivePatterns = [
             /password/i,
             /secret/i,
@@ -335,9 +326,8 @@ export const parameterValidation: MCPSecurityRule = {
         ];
 
         return sensitivePatterns.some(pattern => pattern.test(fieldName));
-    }
-
- private needsFormatValidation(fieldName: string): boolean {
+    },
+  needsFormatValidation(fieldName: string): boolean {
         const formatFields = [
             { pattern: /email/i, format: 'email' },
             { pattern: /url|uri/i, format: 'uri' },
@@ -348,9 +338,8 @@ export const parameterValidation: MCPSecurityRule = {
         ];
 
         return formatFields.some(field => field.pattern.test(fieldName));
-    }
-
- private shouldBePositive(fieldName: string): boolean {
+    },
+  shouldBePositive(fieldName: string): boolean {
         const positivePatterns = [
             /count/i,
             /size/i,
@@ -365,9 +354,8 @@ export const parameterValidation: MCPSecurityRule = {
         ];
 
         return positivePatterns.some(pattern => pattern.test(fieldName));
-    }
-
- private validateFoxCorpSchema(tool: any, context: AnalysisContext): RuleViolation[] {
+    },
+  validateFoxCorpSchema(tool: any, context: AnalysisContext): RuleViolation[] {
         const violations: RuleViolation[] = [];
         const schema = tool.inputSchema;
 
@@ -390,9 +378,8 @@ export const parameterValidation: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
- private isStreamingTool(tool: any): boolean {
+    },
+  isStreamingTool(tool: any): boolean {
         const streamingPatterns = [
             /stream/i,
             /video/i,
@@ -404,9 +391,8 @@ export const parameterValidation: MCPSecurityRule = {
         return streamingPatterns.some(pattern =>
             pattern.test(tool.name) || pattern.test(tool.description || '')
         );
-    }
-
- private isConvivaTool(tool: any): boolean {
+    },
+  isConvivaTool(tool: any): boolean {
         const convivaPatterns = [
             /conviva/i,
             /analytics/i,
@@ -417,9 +403,8 @@ export const parameterValidation: MCPSecurityRule = {
         return convivaPatterns.some(pattern =>
             pattern.test(tool.name) || pattern.test(tool.description || '')
         );
-    }
-
- private isHARTool(tool: any): boolean {
+    },
+  isHARTool(tool: any): boolean {
         const harPatterns = [
             /har/i,
             /http.*archive/i,
@@ -429,9 +414,8 @@ export const parameterValidation: MCPSecurityRule = {
         return harPatterns.some(pattern =>
             pattern.test(tool.name) || pattern.test(tool.description || '')
         );
-    }
-
- private validateStreamingParameters(tool: any, schema: any): RuleViolation[] {
+    },
+  validateStreamingParameters(tool: any, schema: any): RuleViolation[] {
         const violations: RuleViolation[] = [];
 
         // Check for stream ID validation
@@ -468,26 +452,22 @@ export const parameterValidation: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
- private hasStreamIdValidation(streamIdSchema: any): boolean {
+    },
+  hasStreamIdValidation(streamIdSchema: any): boolean {
         return streamIdSchema.pattern &&
             (streamIdSchema.pattern.includes('fox') || streamIdSchema.pattern.includes('[a-zA-Z0-9-]+'));
-    }
-
- private hasContentTypeValidation(contentTypeSchema: any): boolean {
+    },
+  hasContentTypeValidation(contentTypeSchema: any): boolean {
         return contentTypeSchema.enum &&
             contentTypeSchema.enum.some((type: string) =>
                 ['live', 'vod', 'sports', 'news'].includes(type.toLowerCase())
             );
-    }
-
- private hasAssetUrlValidation(assetUrlSchema: any): boolean {
+    },
+  hasAssetUrlValidation(assetUrlSchema: any): boolean {
         return assetUrlSchema.pattern &&
             (assetUrlSchema.pattern.includes('fox') || assetUrlSchema.pattern.includes('\.fox\.'));
-    }
-
- private validateConvivaParameters(tool: any, schema: any): RuleViolation[] {
+    },
+  validateConvivaParameters(tool: any, schema: any): RuleViolation[] {
         const violations: RuleViolation[] = [];
 
         // Check for session ID validation
@@ -513,17 +493,14 @@ export const parameterValidation: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
- private hasSessionIdValidation(sessionIdSchema: any): boolean {
+    },
+  hasSessionIdValidation(sessionIdSchema: any): boolean {
         return sessionIdSchema.pattern && sessionIdSchema.pattern.length > 10;
-    }
-
- private hasMetricNameValidation(metricNameSchema: any): boolean {
+    },
+  hasMetricNameValidation(metricNameSchema: any): boolean {
         return metricNameSchema.enum && metricNameSchema.enum.length > 0;
-    }
-
- private validateHARParameters(tool: any, schema: any): RuleViolation[] {
+    },
+  validateHARParameters(tool: any, schema: any): RuleViolation[] {
         const violations: RuleViolation[] = [];
 
         // Check for HAR file size limits
@@ -549,17 +526,14 @@ export const parameterValidation: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
- private hasHARSizeValidation(harSchema: any): boolean {
+    },
+  hasHARSizeValidation(harSchema: any): boolean {
         return harSchema.maxLength && harSchema.maxLength <= 10000000; // 10MB limit
-    }
-
- private hasHARFormatValidation(harSchema: any): boolean {
+    },
+  hasHARFormatValidation(harSchema: any): boolean {
         return harSchema.type === 'object' && harSchema.properties;
-    }
-
- private async checkValidationImplementation(tool: any, context: AnalysisContext): Promise<RuleViolation[]> {
+    },
+  async checkValidationImplementation(tool: any, context: AnalysisContext): Promise<RuleViolation[]> {
         const violations: RuleViolation[] = [];
 
         // Find tool implementation
@@ -614,9 +588,8 @@ export const parameterValidation: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
- private hasValidationLibraryUsage(file: any): boolean {
+    },
+  hasValidationLibraryUsage(file: any): boolean {
         const content = file.content.toLowerCase();
         const validationLibraries = [
             /joi\./,
@@ -629,9 +602,8 @@ export const parameterValidation: MCPSecurityRule = {
         ];
 
         return validationLibraries.some(lib => lib.test(content));
-    }
-
- private hasSchemaValidation(file: any): boolean {
+    },
+  hasSchemaValidation(file: any): boolean {
         const content = file.content.toLowerCase();
         const validationPatterns = [
             /validate.*schema/,
@@ -645,9 +617,8 @@ export const parameterValidation: MCPSecurityRule = {
         ];
 
         return validationPatterns.some(pattern => pattern.test(content));
-    }
-
- private hasValidationErrorHandling(file: any): boolean {
+    },
+  hasValidationErrorHandling(file: any): boolean {
         const content = file.content.toLowerCase();
         const errorPatterns = [
             /validation.*error/,
@@ -659,9 +630,8 @@ export const parameterValidation: MCPSecurityRule = {
         ];
 
         return errorPatterns.some(pattern => pattern.test(content));
-    }
-
- private checkValidationSchemas(context: AnalysisContext): RuleViolation[] {
+    },
+  checkValidationSchemas(context: AnalysisContext): RuleViolation[] {
         const violations: RuleViolation[] = [];
 
         // Check for consistent schema usage across tools
@@ -716,9 +686,8 @@ export const parameterValidation: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
- private findDuplicateSchemas(schemas: any[]): any[] {
+    },
+  findDuplicateSchemas(schemas: any[]): any[] {
         const schemaStrings = schemas.map(schema => JSON.stringify(schema));
         const duplicates: any[] = [];
         const seen = new Set();
@@ -732,9 +701,8 @@ export const parameterValidation: MCPSecurityRule = {
         }
 
         return duplicates;
-    }
-
- private getLineNumber(sourceFile: ts.SourceFile, node: ts.Node): number {
+    },
+  getLineNumber(sourceFile: ts.SourceFile, node: ts.Node): number {
         return sourceFile.getLineAndCharacterOfPosition(node.getStart()).line + 1;
     }
-};
+} as MCPSecurityRule;

--- a/src/rules/input-validation/sanitization.ts
+++ b/src/rules/input-validation/sanitization.ts
@@ -1,7 +1,7 @@
 import { MCPSecurityRule, AnalysisContext, RuleViolation } from '../../core/types';
 import * as ts from 'typescript';
 
-export const sanitizationRequired: MCPSecurityRule = {
+export const sanitizationRequired = {
     id: 'input-sanitization',
     name: 'Input Sanitization Required',
     description: 'Ensures all user inputs are properly sanitized before processing',
@@ -27,9 +27,8 @@ export const sanitizationRequired: MCPSecurityRule = {
         violations.push(...libraryViolations);
 
         return violations;
-    }
-
-  private async checkToolSanitization(tool: any, context: AnalysisContext): Promise<RuleViolation[]> {
+    },
+  async checkToolSanitization(tool: any, context: AnalysisContext): Promise<RuleViolation[]> {
         const violations: RuleViolation[] = [];
 
         // Find tool implementation
@@ -79,9 +78,8 @@ export const sanitizationRequired: MCPSecurityRule = {
         violations.push(...outputViolations);
 
         return violations;
-    }
-
-  private extractInputParameters(file: any, tool: any): Array<{ name: string, type: string, line: number }> {
+    },
+  extractInputParameters(file: any, tool: any): Array<{ name: string, type: string, line: number }> {
         const parameters: Array<{ name: string, type: string, line: number }> = [];
 
         if (!file.ast) return parameters;
@@ -123,9 +121,8 @@ export const sanitizationRequired: MCPSecurityRule = {
 
         visitor(file.ast);
         return parameters;
-    }
-
-  private getFunctionName(node: ts.FunctionDeclaration | ts.MethodDeclaration | ts.ArrowFunction): string | null {
+    },
+  getFunctionName(node: ts.FunctionDeclaration | ts.MethodDeclaration | ts.ArrowFunction): string | null {
         if (ts.isFunctionDeclaration(node) && node.name) {
             return node.name.text;
         }
@@ -133,9 +130,8 @@ export const sanitizationRequired: MCPSecurityRule = {
             return node.name.text;
         }
         return null;
-    }
-
-  private isParameterSanitized(param: { name: string, type: string, line: number }, file: any): boolean {
+    },
+  isParameterSanitized(param: { name: string, type: string, line: number }, file: any): boolean {
         const content = file.content;
 
         // Look for sanitization calls near the parameter usage
@@ -151,9 +147,8 @@ export const sanitizationRequired: MCPSecurityRule = {
         ];
 
         return sanitizationPatterns.some(pattern => pattern.test(content));
-    }
-
-  private checkSpecificSanitization(
+    },
+  checkSpecificSanitization(
         param: { name: string, type: string, line: number },
         tool: any,
         file: any,
@@ -237,9 +232,8 @@ export const sanitizationRequired: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
-  private needsHTMLSanitization(param: { name: string, type: string }, file: any): boolean {
+    },
+  needsHTMLSanitization(param: { name: string, type: string }, file: any): boolean {
         const content = file.content;
         const htmlPatterns = [
             new RegExp(`${param.name}.*innerHTML`, 'i'),
@@ -251,9 +245,8 @@ export const sanitizationRequired: MCPSecurityRule = {
         ];
 
         return htmlPatterns.some(pattern => pattern.test(content));
-    }
-
-  private hasHTMLSanitization(param: { name: string, type: string }, file: any): boolean {
+    },
+  hasHTMLSanitization(param: { name: string, type: string }, file: any): boolean {
         const content = file.content;
         const sanitizationPatterns = [
             /dompurify/i,
@@ -265,9 +258,8 @@ export const sanitizationRequired: MCPSecurityRule = {
 
         const paramContext = this.getParameterContext(param.name, file);
         return sanitizationPatterns.some(pattern => pattern.test(paramContext));
-    }
-
-  private needsSQLSanitization(param: { name: string, type: string }, file: any): boolean {
+    },
+  needsSQLSanitization(param: { name: string, type: string }, file: any): boolean {
         const content = file.content;
         const sqlPatterns = [
             new RegExp(`query.*${param.name}`, 'i'),
@@ -280,9 +272,8 @@ export const sanitizationRequired: MCPSecurityRule = {
         ];
 
         return sqlPatterns.some(pattern => pattern.test(content));
-    }
-
-  private hasSQLSanitization(param: { name: string, type: string }, file: any): boolean {
+    },
+  hasSQLSanitization(param: { name: string, type: string }, file: any): boolean {
         const paramContext = this.getParameterContext(param.name, file);
 
         // Check for parameterized queries
@@ -302,9 +293,8 @@ export const sanitizationRequired: MCPSecurityRule = {
 
         return parameterizedPatterns.some(pattern => pattern.test(paramContext)) ||
             escapePatterns.some(pattern => pattern.test(paramContext));
-    }
-
-  private needsPathSanitization(param: { name: string, type: string }, file: any): boolean {
+    },
+  needsPathSanitization(param: { name: string, type: string }, file: any): boolean {
         const content = file.content;
         const pathPatterns = [
             new RegExp(`readFile.*${param.name}`, 'i'),
@@ -316,9 +306,8 @@ export const sanitizationRequired: MCPSecurityRule = {
         ];
 
         return pathPatterns.some(pattern => pattern.test(content));
-    }
-
-  private hasPathSanitization(param: { name: string, type: string }, file: any): boolean {
+    },
+  hasPathSanitization(param: { name: string, type: string }, file: any): boolean {
         const paramContext = this.getParameterContext(param.name, file);
         const sanitizationPatterns = [
             /path\.normalize/i,
@@ -331,9 +320,8 @@ export const sanitizationRequired: MCPSecurityRule = {
         ];
 
         return sanitizationPatterns.some(pattern => pattern.test(paramContext));
-    }
-
-  private needsURLSanitization(param: { name: string, type: string }, file: any): boolean {
+    },
+  needsURLSanitization(param: { name: string, type: string }, file: any): boolean {
         const content = file.content;
         const urlPatterns = [
             new RegExp(`fetch.*${param.name}`, 'i'),
@@ -345,9 +333,8 @@ export const sanitizationRequired: MCPSecurityRule = {
         ];
 
         return urlPatterns.some(pattern => pattern.test(content));
-    }
-
-  private hasURLSanitization(param: { name: string, type: string }, file: any): boolean {
+    },
+  hasURLSanitization(param: { name: string, type: string }, file: any): boolean {
         const paramContext = this.getParameterContext(param.name, file);
         const sanitizationPatterns = [
             /url.*parse/i,
@@ -359,9 +346,8 @@ export const sanitizationRequired: MCPSecurityRule = {
         ];
 
         return sanitizationPatterns.some(pattern => pattern.test(paramContext));
-    }
-
-  private isStreamingParameter(param: { name: string, type: string }, file: any): boolean {
+    },
+  isStreamingParameter(param: { name: string, type: string }, file: any): boolean {
         const streamingPatterns = [
             /stream/i,
             /video/i,
@@ -374,9 +360,8 @@ export const sanitizationRequired: MCPSecurityRule = {
 
         return streamingPatterns.some(pattern => pattern.test(param.name)) ||
             streamingPatterns.some(pattern => pattern.test(param.type));
-    }
-
-  private hasStreamingSanitization(param: { name: string, type: string }, file: any): boolean {
+    },
+  hasStreamingSanitization(param: { name: string, type: string }, file: any): boolean {
         const paramContext = this.getParameterContext(param.name, file);
         const sanitizationPatterns = [
             /validate.*stream/i,
@@ -388,9 +373,8 @@ export const sanitizationRequired: MCPSecurityRule = {
         ];
 
         return sanitizationPatterns.some(pattern => pattern.test(paramContext));
-    }
-
-  private getParameterContext(paramName: string, file: any): string {
+    },
+  getParameterContext(paramName: string, file: any): string {
         const content = file.content;
         const lines = content.split('\n');
         const contextLines: string[] = [];
@@ -405,9 +389,8 @@ export const sanitizationRequired: MCPSecurityRule = {
         }
 
         return contextLines.join('\n');
-    }
-
-  private checkDirectInputUsage(file: any, tool: any): RuleViolation[] {
+    },
+  checkDirectInputUsage(file: any, tool: any): RuleViolation[] {
         const violations: RuleViolation[] = [];
 
         if (!file.ast) return violations;
@@ -439,9 +422,8 @@ export const sanitizationRequired: MCPSecurityRule = {
 
         visitor(file.ast);
         return violations;
-    }
-
-  private isDirectUserInput(propertyAccess: string): boolean {
+    },
+  isDirectUserInput(propertyAccess: string): boolean {
         const inputPatterns = [
             /req\.body/,
             /req\.query/,
@@ -457,9 +439,8 @@ export const sanitizationRequired: MCPSecurityRule = {
         ];
 
         return inputPatterns.some(pattern => pattern.test(propertyAccess));
-    }
-
-  private isInSanitizationContext(node: ts.Node, sourceFile: ts.SourceFile): boolean {
+    },
+  isInSanitizationContext(node: ts.Node, sourceFile: ts.SourceFile): boolean {
         // Check if the node is within a sanitization function call
         let current = node.parent;
 
@@ -474,9 +455,8 @@ export const sanitizationRequired: MCPSecurityRule = {
         }
 
         return false;
-    }
-
-  private isSanitizationCall(callText: string): boolean {
+    },
+  isSanitizationCall(callText: string): boolean {
         const sanitizationPatterns = [
             /sanitize/i,
             /clean/i,
@@ -488,9 +468,8 @@ export const sanitizationRequired: MCPSecurityRule = {
         ];
 
         return sanitizationPatterns.some(pattern => pattern.test(callText));
-    }
-
-  private checkOutputSanitization(file: any, tool: any): RuleViolation[] {
+    },
+  checkOutputSanitization(file: any, tool: any): RuleViolation[] {
         const violations: RuleViolation[] = [];
 
         if (!file.ast) return violations;
@@ -536,9 +515,8 @@ export const sanitizationRequired: MCPSecurityRule = {
 
         visitor(file.ast);
         return violations;
-    }
-
-  private containsUnsanitizedInput(text: string, file: any): boolean {
+    },
+  containsUnsanitizedInput(text: string, file: any): boolean {
         const inputPatterns = [
             /req\./,
             /request\./,
@@ -559,9 +537,8 @@ export const sanitizationRequired: MCPSecurityRule = {
         const hasSanitization = sanitizationPatterns.some(pattern => pattern.test(text));
 
         return hasInput && !hasSanitization;
-    }
-
-  private isResponseCall(callText: string): boolean {
+    },
+  isResponseCall(callText: string): boolean {
         const responsePatterns = [
             /res\.send/,
             /res\.json/,
@@ -572,9 +549,8 @@ export const sanitizationRequired: MCPSecurityRule = {
         ];
 
         return responsePatterns.some(pattern => pattern.test(callText));
-    }
-
-  private checkGlobalSanitization(context: AnalysisContext): RuleViolation[] {
+    },
+  checkGlobalSanitization(context: AnalysisContext): RuleViolation[] {
         const violations: RuleViolation[] = [];
 
         // Check for sanitization middleware
@@ -592,9 +568,8 @@ export const sanitizationRequired: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
-  private hasSanitizationMiddleware(file: any): boolean {
+    },
+  hasSanitizationMiddleware(file: any): boolean {
         const content = file.content.toLowerCase();
         const middlewarePatterns = [
             /sanitize.*middleware/,
@@ -604,9 +579,8 @@ export const sanitizationRequired: MCPSecurityRule = {
         ];
 
         return middlewarePatterns.some(pattern => pattern.test(content));
-    }
-
-  private checkSanitizationLibraries(context: AnalysisContext): RuleViolation[] {
+    },
+  checkSanitizationLibraries(context: AnalysisContext): RuleViolation[] {
         const violations: RuleViolation[] = [];
 
         const sanitizationLibs = [
@@ -634,9 +608,8 @@ export const sanitizationRequired: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
-  private getLineNumber(sourceFile: ts.SourceFile, node: ts.Node): number {
+    },
+  getLineNumber(sourceFile: ts.SourceFile, node: ts.Node): number {
         return sourceFile.getLineAndCharacterOfPosition(node.getStart()).line + 1;
     }
-};
+} as MCPSecurityRule;

--- a/src/rules/rate-limiting/rate-limit-enforcement.ts
+++ b/src/rules/rate-limiting/rate-limit-enforcement.ts
@@ -1,7 +1,7 @@
 import { MCPSecurityRule, AnalysisContext, RuleViolation } from '../../core/types';
 import * as ts from 'typescript';
 
-export const rateLimitEnforcement: MCPSecurityRule = {
+export const rateLimitEnforcement = {
     id: 'rate-limit-enforcement',
     name: 'Rate Limit Enforcement',
     description: 'Ensures MCP tools have proper rate limiting to prevent abuse and resource exhaustion',
@@ -27,9 +27,8 @@ export const rateLimitEnforcement: MCPSecurityRule = {
         violations.push(...criticalViolations);
 
         return violations;
-    }
-
-  private async checkToolRateLimit(tool: any, context: AnalysisContext): Promise<RuleViolation[]> {
+    },
+  async checkToolRateLimit(tool: any, context: AnalysisContext): Promise<RuleViolation[]> {
         const violations: RuleViolation[] = [];
 
         // Check if tool has explicit rate limit configuration
@@ -53,9 +52,8 @@ export const rateLimitEnforcement: MCPSecurityRule = {
         violations.push(...implViolations);
 
         return violations;
-    }
-
-  private validateRateLimitConfig(tool: any, context: AnalysisContext): RuleViolation[] {
+    },
+  validateRateLimitConfig(tool: any, context: AnalysisContext): RuleViolation[] {
         const violations: RuleViolation[] = [];
         const rateLimit = tool.rateLimit;
 
@@ -105,9 +103,8 @@ export const rateLimitEnforcement: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
-  private async checkRateLimitImplementation(tool: any, context: AnalysisContext): Promise<RuleViolation[]> {
+    },
+  async checkRateLimitImplementation(tool: any, context: AnalysisContext): Promise<RuleViolation[]> {
         const violations: RuleViolation[] = [];
 
         // Find tool implementation file
@@ -149,9 +146,8 @@ export const rateLimitEnforcement: MCPSecurityRule = {
         violations.push(...bypassViolations);
 
         return violations;
-    }
-
-  private checkForRateLimitingCode(file: any): boolean {
+    },
+  checkForRateLimitingCode(file: any): boolean {
         const content = file.content.toLowerCase();
         const rateLimitPatterns = [
             /rate.*limit/,
@@ -164,9 +160,8 @@ export const rateLimitEnforcement: MCPSecurityRule = {
         ];
 
         return rateLimitPatterns.some(pattern => pattern.test(content));
-    }
-
-  private checkForRateLimitErrorHandling(file: any): boolean {
+    },
+  checkForRateLimitErrorHandling(file: any): boolean {
         const content = file.content.toLowerCase();
         const errorPatterns = [
             /429/,  // Too Many Requests status code
@@ -177,9 +172,8 @@ export const rateLimitEnforcement: MCPSecurityRule = {
         ];
 
         return errorPatterns.some(pattern => pattern.test(content));
-    }
-
-  private checkRateLimitBypass(file: any): RuleViolation[] {
+    },
+  checkRateLimitBypass(file: any): RuleViolation[] {
         const violations: RuleViolation[] = [];
 
         if (!file.ast) return violations;
@@ -221,9 +215,8 @@ export const rateLimitEnforcement: MCPSecurityRule = {
 
         visitor(file.ast);
         return violations;
-    }
-
-  private isPrivilegedBypass(condition: string): boolean {
+    },
+  isPrivilegedBypass(condition: string): boolean {
         const privilegedPatterns = [
             /admin/i,
             /root/i,
@@ -233,9 +226,8 @@ export const rateLimitEnforcement: MCPSecurityRule = {
         ];
 
         return privilegedPatterns.some(pattern => pattern.test(condition));
-    }
-
-  private isIPBasedBypass(condition: string): boolean {
+    },
+  isIPBasedBypass(condition: string): boolean {
         const ipPatterns = [
             /ip.*===.*['"]/,
             /whitelist.*ip/i,
@@ -244,9 +236,8 @@ export const rateLimitEnforcement: MCPSecurityRule = {
         ];
 
         return ipPatterns.some(pattern => pattern.test(condition));
-    }
-
-  private checkGlobalRateLimit(context: AnalysisContext): RuleViolation[] {
+    },
+  checkGlobalRateLimit(context: AnalysisContext): RuleViolation[] {
         const violations: RuleViolation[] = [];
 
         // Check for global rate limiting middleware
@@ -288,9 +279,8 @@ export const rateLimitEnforcement: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
-  private checkCriticalToolsRateLimit(context: AnalysisContext): RuleViolation[] {
+    },
+  checkCriticalToolsRateLimit(context: AnalysisContext): RuleViolation[] {
         const violations: RuleViolation[] = [];
 
         // Tools that MUST have rate limiting
@@ -311,9 +301,8 @@ export const rateLimitEnforcement: MCPSecurityRule = {
         }
 
         return violations;
-    }
-
-  private isHighRiskTool(tool: any): boolean {
+    },
+  isHighRiskTool(tool: any): boolean {
         const highRiskPatterns = [
             /admin/i,
             /system/i,
@@ -329,9 +318,8 @@ export const rateLimitEnforcement: MCPSecurityRule = {
         return highRiskPatterns.some(pattern =>
             pattern.test(tool.name) || pattern.test(tool.description || '')
         );
-    }
-
-  private isStreamingTool(tool: any): boolean {
+    },
+  isStreamingTool(tool: any): boolean {
         const streamingPatterns = [
             /stream/i,
             /video/i,
@@ -345,21 +333,18 @@ export const rateLimitEnforcement: MCPSecurityRule = {
         return streamingPatterns.some(pattern =>
             pattern.test(tool.name) || pattern.test(tool.description || '')
         );
-    }
-
-  private getToolRiskLevel(tool: any): string {
+    },
+  getToolRiskLevel(tool: any): string {
         if (this.isHighRiskTool(tool)) return 'HIGH_RISK';
         if (this.isStreamingTool(tool)) return 'STREAMING';
         return 'STANDARD';
-    }
-
-  private getToolCategory(tool: any): string {
+    },
+  getToolCategory(tool: any): string {
         if (this.isStreamingTool(tool)) return 'Streaming/Media';
         if (this.isHighRiskTool(tool)) return 'System/Admin';
         return 'General';
-    }
-
-  private getLineNumber(sourceFile: ts.SourceFile, node: ts.Node): number {
+    },
+  getLineNumber(sourceFile: ts.SourceFile, node: ts.Node): number {
         return sourceFile.getLineAndCharacterOfPosition(node.getStart()).line + 1;
     }
-};
+} as MCPSecurityRule;


### PR DESCRIPTION
## Summary
- remove `private` keywords from rule definitions
- assert rule objects as `MCPSecurityRule`
- ensure helper methods work as object methods

## Testing
- `npx tsc --noEmit --pretty false` *(fails: Cannot find module 'typescript' or its corresponding type declarations)*