### PR TITLE
Use async file writing for report generation

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -62,7 +62,7 @@ program
 
       // Output results
       if (options.output) {
-        await reporter.writeReport(report, options.output, options.format);
+        await reporter.writeReport(report, options.output);
         console.log(chalk.green(`✅ Report written to ${options.output}`));
       } else {
         console.log(report);

--- a/src/core/reporter.ts
+++ b/src/core/reporter.ts
@@ -1,5 +1,5 @@
 import { RuleViolation, MCPSecConfig } from './types';
-import { writeFileSync } from 'fs';
+import { promises as fs } from 'fs';
 import chalk from 'chalk';
 
 export class SecurityReporter {
@@ -19,8 +19,8 @@ export class SecurityReporter {
     }
   }
 
-  async writeReport(report: string, outputPath: string, format: string): Promise<void> {
-    writeFileSync(outputPath, report, 'utf-8');
+  async writeReport(report: string, outputPath: string): Promise<void> {
+    await fs.writeFile(outputPath, report, 'utf-8');
   }
 
   private generateTextReport(violations: RuleViolation[]): string {


### PR DESCRIPTION
## Summary
- use `fs.promises.writeFile` for report output
- update CLI to match new method signature

## Testing
- `npm run build` *(fails: Cannot find module 'typescript' or corresponding type declarations)*